### PR TITLE
Forgot to remove the commented Hardcoded credentials in connection Util

### DIFF
--- a/src/main/java/in/lingtan/util/ConnectionUtil.java
+++ b/src/main/java/in/lingtan/util/ConnectionUtil.java
@@ -29,7 +29,6 @@ public class ConnectionUtil {
 		
 		return DriverManager.getConnection(url, username, password);
 		
-	//org.postgresql.Driver  jdbc:postgresql://localhost/employeedb postgres @Lingtan1112
 	}
 	
 	/**


### PR DESCRIPTION
Removed the hardcoded credentials that were commented in the program file
